### PR TITLE
Added fixes to the TSX redux+react todoMVC

### DIFF
--- a/generators/todoMVC/modules/templates/src/app/components/MainSection.tsx
+++ b/generators/todoMVC/modules/templates/src/app/components/MainSection.tsx
@@ -90,7 +90,7 @@ class MainSection extends React.Component<IMainProps, IMainState> {
       <section className='main'>
         {this.renderToggleAll(completedCount)}
         <ul className='todo-list'>
-          {filteredTodos.map(todo =>
+          {filteredTodos.map((todo: any) =>
             <TodoItem
               key={todo.id}
               todo={todo}

--- a/generators/todoMVC/modules/templates/src/app/containers/App.tsx
+++ b/generators/todoMVC/modules/templates/src/app/containers/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {IDispatch} from '~react-redux~redux';
+import {Dispatch} from 'redux';
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import Header from '../components/Header';
@@ -7,8 +7,8 @@ import MainSection from '../components/MainSection';
 import {addTodo, deleteTodo, editTodo, completeTodo, completeAll, clearCompleted} from '../actions/index';
 
 interface IAppProps {
-  todos?: any[];
-  actions?: any;
+  todos: any[];
+  actions: any;
 }
 
 interface IAppState {}
@@ -41,7 +41,7 @@ function mapStateToProps(state: any) {
   };
 }
 
-function mapDispatchToProps(dispatch: IDispatch) {
+function mapDispatchToProps(dispatch: Dispatch<any>) {
   return {
     actions: bindActionCreators({
       addTodo,

--- a/generators/todoMVC/modules/templates/src/index.tsx
+++ b/generators/todoMVC/modules/templates/src/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import {IStore} from '~react-redux~redux';
+import {Store} from 'redux';
 import {Provider} from 'react-redux';
 import App from './app/containers/App';
 import configureStore from './app/store/configureStore';
@@ -10,7 +10,7 @@ import {Router, Route, browserHistory} from 'react-router';
 
 import 'todomvc-app-css/index.css<%- modules === 'systemjs' ? '!' : '' %>';
 
-const store: IStore<any> = configureStore({});
+const store: Store<any> = configureStore({});
 
 ReactDOM.render(
   <Provider store={store}>


### PR DESCRIPTION
According to this issuse:
 https://github.com/FountainJS/generator-fountain-react/issues/70

I have fixed all the mentioned problems according to the advice in the issue itself by @bradharms
```
ERROR in ./src/app/containers/App.tsx
(2,25): error TS2307: Cannot find module '~react-redux~redux'.

ERROR in ./src/app/containers/App.tsx
(60,3): error TS2345: Argument of type 'typeof App' is not assignable to parameter of type 'Component<{ todos: any; } & { actions: { addTodo: (text: string) => { type: string; text: string;...'.
  Type 'typeof App' is not assignable to type 'StatelessComponent<{ todos: any; } & { actions: { addTodo: (text: string) => { type: string; text...'.
    Type 'typeof App' provides no match for the signature '(props: { todos: any; } & { actions: { addTodo: (text: string) => { type: string; text: string; }; deleteTodo: (id: number) => { type: string; id: number; }; editTodo: (id: number, text: string) => { type: string; id: number; text: string; }; completeTodo: (id: number) => { type: string; id: number; }; completeAll: () => { type: string; }; clearCompleted: () => { type: string; }; }; } & { children?: ReactNode; }, context?: any): ReactElement<any>'.

ERROR in ./src/app/components/MainSection.tsx
(95,25): error TS2339: Property 'id' does not exist on type '{}'.

ERROR in ./src/index.tsx
(3,22): error TS2307: Cannot find module '~react-redux~redux'.
```

The fixes make sure the typings are correct and make it so `gulp build` passes correctly.

